### PR TITLE
fix(ovh-password): add strength check template in cache

### DIFF
--- a/src/ovh-password/index.js
+++ b/src/ovh-password/index.js
@@ -8,6 +8,7 @@ import 'ovh-ngstrap';
 import tucOvhPasswordDirective from './ovh-password';
 import tucOvhPasswordStrengthBarDirective from './strength/bar/ovh-password-strength-bar';
 import tucOvhPasswordStrengthCheckDirective from './strength/check/ovh-password-strength-check';
+import tucOvhPasswordStrengthCheckTemplate from './strength/check/ovh-password-strength-check.html';
 
 import './ovh-password.less';
 
@@ -28,6 +29,12 @@ angular
       animation: 'flat-fade',
     });
   })
-  .run(/* @ngTranslationsInject ./translations */);
+  .run(/* @ngTranslationsInject ./translations */)
+  .run(/* @ngInject */ ($templateCache) => {
+    $templateCache.put(
+      'telecomUniverseComponents/ovh-password/strength/check/ovh-password-strength-check.html',
+      tucOvhPasswordStrengthCheckTemplate,
+    );
+  });
 
 export default moduleName;


### PR DESCRIPTION
## fix(ovh-password): add strength check template in cache

### Description of the Change

Fix `ovh-password` popover to display strength check content.

220c86f — fix(ovh-password): add strength check template in cache

ref: 

/cc @jleveugle @frenautvh @antleblanc

